### PR TITLE
feat(unix): Adds more ergonomic interface for send/receive message

### DIFF
--- a/.versioning/changes/sx4yxJGVYB.minor.md
+++ b/.versioning/changes/sx4yxJGVYB.minor.md
@@ -1,0 +1,1 @@
+Added a more ergonomic interface for `send_message` and `receive_message` on `UnixSocket`

--- a/include/exios/buffer_view.hpp
+++ b/include/exios/buffer_view.hpp
@@ -4,7 +4,9 @@
 #include <array>
 #include <cstddef>
 #include <span>
+#include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace exios
@@ -22,45 +24,83 @@ struct ConstBufferView
 };
 
 template <typename T>
-requires(!std::is_const_v<T>)
+requires(!std::is_const_v<T> && std::is_trivially_copyable_v<T>)
 auto buffer_view(std::span<T> val) noexcept
 {
-    return BufferView { val.data(), val.size() };
+    return BufferView { val.data(), sizeof(T) * val.size() };
 }
 
 template <typename T>
+requires(std::is_trivially_copyable_v<T>)
 auto const_buffer_view(std::span<T> val) noexcept
 {
-    return ConstBufferView { val.data(), val.size() };
+    return ConstBufferView { val.data(), sizeof(T) * val.size() };
 }
 
 template <typename T>
-requires(!std::is_const_v<T>)
+requires(!std::is_const_v<T> && std::is_trivially_copyable_v<T>)
 auto buffer_view(std::vector<T>& val) noexcept
 {
-    return BufferView { val.data(), val.size() };
+    return BufferView { val.data(), sizeof(T) * val.size() };
 }
 
 template <typename T>
-auto const_buffer_view(std::vector<T>& val) noexcept
+requires(std::is_trivially_copyable_v<T>)
+auto const_buffer_view(std::vector<T> const& val) noexcept
 {
-    return ConstBufferView { val.data(), val.size() };
+    return ConstBufferView { val.data(), sizeof(T) * val.size() };
 }
 
-auto const_buffer_view(std::string_view val) noexcept -> ConstBufferView;
+template <typename T>
+auto const_buffer_view(std::vector<T> const&& val) noexcept
+    -> ConstBufferView = delete;
+
+template <typename T, typename Traits, typename Allocator>
+requires(std::is_trivially_copyable_v<T>)
+auto const_buffer_view(std::basic_string_view<T, Traits> val) noexcept
+    -> ConstBufferView
+{
+    return ConstBufferView { val.data(), sizeof(T) * val.size() };
+}
+
+template <typename T, typename Traits, typename Allocator>
+requires(!std::is_const_v<T> && std::is_trivially_copyable_v<T>)
+auto buffer_view(std::basic_string<T, Traits, Allocator>& val) noexcept
+    -> BufferView
+{
+    return BufferView { val.data(), sizeof(T) * val.size() };
+}
+
+template <typename T, typename Traits, typename Allocator>
+requires(std::is_trivially_copyable_v<T>)
+auto const_buffer_view(
+    std::basic_string<T, Traits, Allocator> const& val) noexcept
+    -> ConstBufferView
+{
+    return ConstBufferView { val.data(), sizeof(T) * val.size() };
+}
+
+template <typename T, typename Traits, typename Allocator>
+auto const_buffer_view(std::basic_string<T, Traits, Allocator> const&&)
+    -> ConstBufferView = delete;
 
 template <typename T, std::size_t N>
-requires(!std::is_const_v<T>)
+requires(!std::is_const_v<T> && std::is_trivially_copyable_v<T>)
 auto buffer_view(std::array<T, N>& val) noexcept
 {
-    return BufferView { val.data(), N };
+    return BufferView { val.data(), sizeof(T) * N };
 }
 
 template <typename T, std::size_t N>
-auto const_buffer_view(std::array<T, N>& val) noexcept
+requires(std::is_trivially_copyable_v<T>)
+auto const_buffer_view(std::array<T, N> const& val) noexcept
 {
-    return ConstBufferView { val.data(), N };
+    return ConstBufferView { val.data(), sizeof(T) * N };
 }
+
+template <typename T, std::size_t N>
+auto const_buffer_view(std::array<T, N> const&& val) noexcept
+    -> ConstBufferView = delete;
 
 } // namespace exios
 

--- a/include/exios/io.hpp
+++ b/include/exios/io.hpp
@@ -3,6 +3,7 @@
 
 #include "exios/buffer_view.hpp"
 #include "exios/contracts.hpp"
+#include "exios/message.hpp"
 #include "exios/result.hpp"
 #include <cinttypes>
 #include <netinet/in.h>
@@ -12,6 +13,7 @@
 #include <sys/un.h>
 #include <system_error>
 #include <tuple>
+#include <type_traits>
 
 namespace exios
 {
@@ -45,8 +47,21 @@ struct UnixAcceptOperation
 struct ReceiveMessageOperation
 {
 };
+
 struct SendMessageOperation
 {
+};
+
+template <typename Allocator>
+struct SendMessageManagedOperation
+{
+    using allocator = std::remove_cvref_t<Allocator>;
+};
+
+template <typename Allocator>
+struct ReceiveMessageManagedOperation
+{
+    using allocator = std::remove_cvref_t<Allocator>;
 };
 
 struct NetConnectOperation
@@ -75,7 +90,23 @@ constexpr NetConnectOperation net_connect_operation {};
 constexpr NetSendToOperation net_send_to_operation {};
 constexpr NetReceiveFromOperation net_receive_from_operation {};
 
+template <typename Allocator>
+constexpr auto send_message_managed_operation() noexcept
+    -> SendMessageManagedOperation<Allocator>
+{
+    return {};
+}
+
+template <typename Allocator>
+constexpr auto receive_message_managed_operation() noexcept
+    -> ReceiveMessageManagedOperation<Allocator>
+{
+    return {};
+}
+
 using IoResult = Result<std::size_t, std::error_code>;
+using ReceiveMessageManagedResult =
+    Result<std::pair<std::size_t, std::size_t>, std::error_code>;
 using ConnectResult = Result<std::error_code>;
 using AcceptResult = Result<int, std::error_code>;
 using TimerOrEventIoResult = Result<std::uint64_t, std::error_code>;
@@ -88,6 +119,8 @@ using ReceiveFromResult =
 auto perform_read(int fd, BufferView buffer) noexcept -> IoResult;
 auto perform_write(int fd, ConstBufferView buffer) noexcept -> IoResult;
 auto perform_timer_or_event_read(int fd) noexcept -> TimerOrEventIoResult;
+auto perform_send(int fd, msghdr const& buf) noexcept -> IoResult;
+auto perform_receive(int fd, msghdr& buf) noexcept -> ReceiveMessageResult;
 
 struct IoOpBase
 {
@@ -167,6 +200,143 @@ struct SendMessage
 private:
     std::optional<IoResult> result_;
     msghdr msg_;
+};
+
+template <typename Allocator>
+struct SendMessageManaged
+{
+    explicit SendMessageManaged(outgoing_message_base<Allocator> msg) noexcept
+        : msg_ { std::move(msg) }
+    {
+    }
+
+    auto io(int fd) noexcept -> bool
+    {
+        EXIOS_EXPECT(!result_);
+        msghdr tmp;
+        try {
+            tmp = message_view(msg_);
+        }
+        catch (...) {
+            result_.emplace(result_error(
+                std::error_code { static_cast<int>(std::errc::no_buffer_space),
+                                  std::system_category() }));
+            return true;
+        }
+
+        std::array<iovec, 1> iov { iovec {
+            const_cast<void*>(msg_.data_buffer().data),
+            msg_.data_buffer().size } };
+        tmp.msg_iov = iov.data();
+        tmp.msg_iovlen = iov.size();
+
+        auto r = perform_send(fd, tmp);
+        if (!r && (r.error() == std::errc::operation_in_progress ||
+                   r.error() == std::errc::operation_would_block))
+            return false;
+
+        result_.emplace(std::move(r));
+        return true;
+    }
+
+    auto cancel() noexcept -> void
+    {
+        result_.emplace(
+            result_error(std::make_error_code(std::errc::operation_canceled)));
+    }
+
+    static constexpr auto is_readable = std::false_type {};
+
+    template <typename F>
+    auto dispatch(F&& f) -> void
+    {
+        EXIOS_EXPECT(result_);
+        std::forward<F>(f)(std::move(*result_));
+    }
+
+private:
+    std::optional<IoResult> result_;
+    outgoing_message_base<Allocator> msg_;
+};
+
+template <typename Allocator>
+struct ReceiveMessageManaged
+{
+    explicit ReceiveMessageManaged(
+        incoming_message_base<Allocator> msg) noexcept
+        : msg_ { std::move(msg) }
+    {
+    }
+
+    auto io(int fd) noexcept -> bool
+    {
+        EXIOS_EXPECT(!result_);
+        msghdr tmp;
+        try {
+            tmp = message_view(msg_);
+        }
+        catch (...) {
+            result_.emplace(result_error(
+                std::error_code { static_cast<int>(std::errc::no_buffer_space),
+                                  std::system_category() }));
+            return true;
+        }
+
+        std::array<iovec, 1> iov { iovec {
+            const_cast<void*>(msg_.data_buffer().data),
+            msg_.data_buffer().size } };
+        tmp.msg_iov = iov.data();
+        tmp.msg_iovlen = iov.size();
+
+        auto r = perform_receive(fd, tmp);
+        if (!r && (r.error() == std::errc::operation_in_progress ||
+                   r.error() == std::errc::operation_would_block))
+            return false;
+
+        if (!r) {
+            result_.emplace(result_error(r.error()));
+            return true;
+        }
+
+        std::size_t control_bytes_copied = 0;
+
+        if (msg_.control_buffer().size) {
+            auto control_buffer = msg_.control_buffer();
+            cmsghdr* cmsg = CMSG_FIRSTHDR(&tmp);
+            EXIOS_EXPECT(cmsg);
+            std::size_t const bytes_to_copy =
+                std::min(cmsg->cmsg_len, control_buffer.size);
+
+            std::copy_n(reinterpret_cast<std::uint8_t const*>(CMSG_DATA(cmsg)),
+                        bytes_to_copy,
+                        reinterpret_cast<std::uint8_t*>(control_buffer.data));
+
+            control_bytes_copied = bytes_to_copy;
+        }
+
+        result_.emplace(result_ok(
+            std::make_pair(std::get<0>(r.value()), control_bytes_copied)));
+        return true;
+    }
+
+    auto cancel() noexcept -> void
+    {
+        result_.emplace(
+            result_error(std::make_error_code(std::errc::operation_canceled)));
+    }
+
+    static constexpr auto is_readable = std::false_type {};
+
+    template <typename F>
+    auto dispatch(F&& f) -> void
+    {
+        EXIOS_EXPECT(result_);
+        std::forward<F>(f)(std::move(*result_));
+    }
+
+private:
+    std::optional<ReceiveMessageManagedResult> result_;
+    incoming_message_base<Allocator> msg_;
 };
 
 struct NetSendTo
@@ -382,6 +552,18 @@ template <>
 struct IoOperation<SendMessageOperation>
 {
     using type = SendMessage;
+};
+
+template <typename Allocator>
+struct IoOperation<SendMessageManagedOperation<Allocator>>
+{
+    using type = SendMessageManaged<std::remove_cvref_t<Allocator>>;
+};
+
+template <typename Allocator>
+struct IoOperation<ReceiveMessageManagedOperation<Allocator>>
+{
+    using type = ReceiveMessageManaged<std::remove_cvref_t<Allocator>>;
 };
 
 template <>

--- a/include/exios/message.hpp
+++ b/include/exios/message.hpp
@@ -1,0 +1,172 @@
+#ifndef EXIOS_MESSAGE_HPP_INCLUDED
+#define EXIOS_MESSAGE_HPP_INCLUDED
+
+#include "buffer_view.hpp"
+#include <algorithm>
+#include <cstdint>
+#include <sys/socket.h>
+#include <type_traits>
+
+namespace exios
+{
+
+namespace direction
+{
+// clang-format off
+inline constexpr struct Outgoing { } outgoing {};
+inline constexpr struct Incoming { } incoming {};
+// clang-format on
+} // namespace direction
+
+template <typename Dir>
+requires(std::is_same_v<Dir, direction::Outgoing> ||
+         std::is_same_v<Dir, direction::Incoming>)
+using buffer_view_type_for_direction =
+    std::conditional_t<std::is_same_v<Dir, direction::Outgoing>,
+                       ConstBufferView,
+                       BufferView>;
+
+template <typename Dir, typename Allocator>
+requires(std::is_same_v<Dir, direction::Outgoing> ||
+         std::is_same_v<Dir, direction::Incoming>)
+struct message_base
+{
+    using allocator =
+        std::allocator_traits<Allocator>::template rebind_alloc<std::uint8_t>;
+
+    static constexpr bool is_outgoing =
+        std::is_same_v<Dir, direction::Outgoing>;
+
+    using buffer_view_type = buffer_view_type_for_direction<Dir>;
+
+    template <typename UAllocator>
+    explicit message_base(UAllocator const& alloc) noexcept
+        : control_buffer_internal_ { allocator(alloc) }
+    {
+    }
+
+    message_base() noexcept
+    requires(std::is_default_constructible_v<allocator>)
+        : message_base(allocator {})
+    {
+    }
+
+    template <typename UAllocator>
+    message_base(UAllocator const& alloc,
+                 buffer_view_type data_buffer,
+                 buffer_view_type control_buffer) noexcept
+        : control_buffer_internal_ { allocator(alloc) }
+        , control_buffer_ { control_buffer }
+        , data_buffer_ { data_buffer }
+    {
+    }
+
+    template <typename UAllocator>
+    message_base(UAllocator const& alloc, buffer_view_type data_buffer) noexcept
+        : control_buffer_internal_ { allocator(alloc) }
+        , control_buffer_ {}
+        , data_buffer_ { data_buffer }
+    {
+    }
+
+    message_base(buffer_view_type data_buffer) noexcept
+    requires(std::is_default_constructible_v<allocator>)
+        : message_base(allocator {}, data_buffer, buffer_view_type {})
+    {
+    }
+
+    message_base(buffer_view_type data_buffer,
+                 buffer_view_type control_buffer) noexcept
+    requires(std::is_default_constructible_v<allocator>)
+        : message_base(allocator {}, data_buffer, control_buffer)
+    {
+    }
+
+    auto set_control_buffer(buffer_view_type buffer) -> message_base&
+    {
+        control_buffer_ = buffer;
+        if (control_buffer_.size) {
+            control_buffer_internal_.resize(CMSG_SPACE(control_buffer().size));
+        }
+
+        return *this;
+    }
+
+    auto set_data_buffer(buffer_view_type buffer) noexcept -> message_base&
+    {
+        data_buffer_ = buffer;
+        return *this;
+    }
+
+    [[nodiscard]] auto control_buffer() const noexcept -> buffer_view_type
+    {
+        return control_buffer_;
+    }
+
+    [[nodiscard]] auto data_buffer() const noexcept -> buffer_view_type
+    {
+        return data_buffer_;
+    }
+
+    [[nodiscard]] friend auto message_view(message_base& msg) -> msghdr
+    {
+        auto result = msghdr {};
+
+        if (msg.control_buffer_.size) {
+            msg.control_buffer_internal_.resize(
+                CMSG_SPACE(msg.control_buffer().size));
+
+            result.msg_control = msg.control_buffer_internal_.data();
+            result.msg_controllen = msg.control_buffer_internal_.size();
+
+            if constexpr (is_outgoing) {
+                auto* hdr = CMSG_FIRSTHDR(&result);
+                hdr->cmsg_level = SOL_SOCKET;
+                hdr->cmsg_type = SCM_RIGHTS;
+                hdr->cmsg_len = CMSG_LEN(msg.control_buffer().size);
+
+                std::copy_n(reinterpret_cast<std::uint8_t const*>(
+                                msg.control_buffer().data),
+                            msg.control_buffer().size,
+                            reinterpret_cast<std::uint8_t*>(CMSG_DATA(hdr)));
+            }
+        }
+
+        return result;
+    }
+
+private:
+    std::vector<std::uint8_t, allocator> control_buffer_internal_;
+    buffer_view_type control_buffer_ {};
+    buffer_view_type data_buffer_ {};
+};
+
+template <typename Allocator>
+using incoming_message_base = message_base<direction::Incoming, Allocator>;
+
+template <typename Allocator>
+using outgoing_message_base = message_base<direction::Outgoing, Allocator>;
+
+template <typename Dir, typename Allocator>
+[[nodiscard]] auto message_view(message_base<Dir, Allocator>& msg,
+                                buffer_view_type_for_direction<Dir> data_buffer)
+{
+    msg.set_data_buffer(data_buffer);
+    msg.set_control_buffer(buffer_view_type_for_direction<Dir> {});
+    return message_view(msg);
+}
+
+template <typename Dir, typename Allocator>
+[[nodiscard]] auto
+message_view(message_base<Dir, Allocator>& msg,
+             buffer_view_type_for_direction<Dir> data_buffer,
+             buffer_view_type_for_direction<Dir> control_buffer)
+{
+    msg.set_data_buffer(data_buffer);
+    msg.set_control_buffer(control_buffer);
+    return message_view(msg);
+}
+
+} // namespace exios
+
+#endif // EXIOS_MESSAGE_HPP_INCLUDED

--- a/include/exios/unix_socket.hpp
+++ b/include/exios/unix_socket.hpp
@@ -2,12 +2,15 @@
 #define EXIOS_UNIX_SOCKET_HPP_INCLUDED
 
 #include "exios/alloc_utils.hpp"
+#include "exios/buffer_view.hpp"
 #include "exios/context.hpp"
 #include "exios/io.hpp"
 #include "exios/io_object.hpp"
+#include "exios/message.hpp"
 #include <string_view>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <utility>
 
 namespace exios
 {
@@ -83,6 +86,49 @@ struct UnixSocket : IoObject
         schedule_io(op);
     }
 
+    /**
+     * \brief receive message with control data
+     * \param data_buffer The standard data to receive
+     * \param control_buffer The control data to receive
+     * \param completion A callable that accepts a
+     * ::exios::ReceiveMessageManagedResult
+     */
+    template <typename F>
+    auto receive_message(BufferView data_buffer,
+                         BufferView control_buffer,
+                         F&& completion) -> void
+    {
+        auto const alloc = select_allocator(completion);
+        incoming_message_base<std::remove_cvref_t<decltype(alloc)>> msg {
+            alloc, data_buffer
+        };
+        msg.set_control_buffer(control_buffer);
+
+        auto* op =
+            make_async_io_operation(receive_message_managed_operation<
+                                        std::remove_cvref_t<decltype(alloc)>>(),
+                                    wrap_work(std::move(completion), ctx_),
+                                    alloc,
+                                    ctx_,
+                                    fd_.value(),
+                                    std::move(msg));
+
+        schedule_io(op);
+    }
+
+    /**
+     * \brief receive message
+     * \param data_buffer The standard data to receive
+     * \param completion A callable that accepts a
+     * ::exios::ReceiveMessageManagedResult
+     */
+    template <typename F>
+    auto receive_message(BufferView data_buffer, F&& completion) -> void
+    {
+        receive_message(
+            data_buffer, BufferView {}, std::forward<F>(completion));
+    }
+
     template <typename F>
     auto write(ConstBufferView buffer, F&& completion) -> void
     {
@@ -113,6 +159,47 @@ struct UnixSocket : IoObject
                                     msg);
 
         schedule_io(op);
+    }
+
+    /**
+     * \brief send message with control data
+     * \param data_buffer The standard data to send
+     * \param control_buffer The control data to send
+     * \param completion A callable that accepts a ::exios::SendMessageResult
+     */
+    template <typename F>
+    auto send_message(ConstBufferView data_buffer,
+                      ConstBufferView control_buffer,
+                      F&& completion) -> void
+    {
+        auto const alloc = select_allocator(completion);
+        outgoing_message_base<std::remove_cvref_t<decltype(alloc)>> msg {
+            alloc, data_buffer
+        };
+        msg.set_control_buffer(control_buffer);
+
+        auto* op =
+            make_async_io_operation(send_message_managed_operation<
+                                        std::remove_cvref_t<decltype(alloc)>>(),
+                                    wrap_work(std::move(completion), ctx_),
+                                    alloc,
+                                    ctx_,
+                                    fd_.value(),
+                                    std::move(msg));
+
+        schedule_io(op);
+    }
+
+    /**
+     * \brief send message
+     * \param data_buffer The standard data to send
+     * \param completion A callable that accepts a ::exios::SendMessageResult
+     */
+    template <typename F>
+    auto send_message(ConstBufferView data_buffer, F&& completion) -> void
+    {
+        send_message(
+            data_buffer, ConstBufferView {}, std::forward<F>(completion));
     }
 
 private:

--- a/tests/unix_socket_tests.cpp
+++ b/tests/unix_socket_tests.cpp
@@ -1,5 +1,7 @@
+#include "exios/buffer_view.hpp"
 #include "exios/context_thread.hpp"
 #include "exios/exios.hpp"
+#include "exios/message.hpp"
 #include "exios/unix_socket.hpp"
 #include "testing.hpp"
 #include <fcntl.h>
@@ -155,7 +157,8 @@ auto write_to_files_and_send(std::string_view content,
         {
         };
         exios::UnixSocket& socket;
-        msghdr message;
+        exios::ConstBufferView data_buffer;
+        exios::ConstBufferView control_buffer;
 
         auto initiate(std::string_view connect_to) && -> void
         {
@@ -170,12 +173,17 @@ auto write_to_files_and_send(std::string_view content,
             EXPECT(result);
 
             socket.send_message(
-                message,
+                data_buffer,
+                control_buffer,
                 std::bind(std::move(*this), OnSend {}, std::placeholders::_1));
         }
 
         auto operator()(OnSend, exios::IoResult result) -> void
         {
+            if (!result) {
+                std::cerr << "SenderPeer error: " << result.error().message()
+                          << '\n';
+            }
             EXPECT(result);
         }
     };
@@ -202,22 +210,17 @@ auto write_to_files_and_send(std::string_view content,
     EXPECT(n == len);
     ::fsync(fd);
 
-    msghdr msg {};
-    char cmsgbuf[CMSG_SPACE(sizeof(int))] = {};
-    msg.msg_control = cmsgbuf;
-    msg.msg_controllen = CMSG_SPACE(sizeof(int));
-
-    cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
-    cmsg->cmsg_level = SOL_SOCKET;
-    cmsg->cmsg_type = SCM_RIGHTS;
-    cmsg->cmsg_len = CMSG_LEN(sizeof(int));
-    *reinterpret_cast<int*>(CMSG_DATA(cmsg)) = fd;
     std::size_t num_fds = 1;
-    iovec data { &num_fds, sizeof(std::size_t) };
-    msg.msg_iov = &data;
-    msg.msg_iovlen = 1;
 
-    SenderPeer(socket, msg).initiate(socket_name);
+    auto sender = SenderPeer(
+        socket,
+        exios::ConstBufferView { .data =
+                                     reinterpret_cast<void const*>(&num_fds),
+                                 .size = sizeof(num_fds) },
+        exios::ConstBufferView { .data = reinterpret_cast<void const*>(&fd),
+                                 .size = sizeof(fd) });
+
+    std::move(sender).initiate(socket_name);
     static_cast<void>(thread.run());
 }
 
@@ -233,7 +236,9 @@ auto should_transfer_file_descriptors() -> void
         };
         exios::UnixSocketAcceptor& acceptor;
         exios::UnixSocket& socket;
-        msghdr& message;
+        exios::BufferView data_buffer;
+        exios::BufferView control_buffer;
+        std::pair<std::size_t, std::size_t>& sizes;
 
         auto initiate() && -> void
         {
@@ -246,15 +251,22 @@ auto should_transfer_file_descriptors() -> void
         auto operator()(OnAccept, exios::Result<std::error_code> result) -> void
         {
             EXPECT(result);
-            socket.receive_message(message,
+            socket.receive_message(data_buffer,
+                                   control_buffer,
                                    std::bind(std::move(*this),
                                              OnReceive {},
                                              std::placeholders::_1));
         }
 
-        auto operator()(OnReceive, exios::ReceiveMessageResult result) -> void
+        auto operator()(OnReceive, exios::ReceiveMessageManagedResult result)
+            -> void
         {
+            if (!result) {
+                std::cerr << "OnReceive error: " << result.error().message()
+                          << '\n';
+            }
             EXPECT(result);
+            sizes = result.value();
         }
     };
 
@@ -262,16 +274,16 @@ auto should_transfer_file_descriptors() -> void
     exios::UnixSocketAcceptor acceptor { thread, "test"sv };
     exios::UnixSocket socket { thread };
 
-    msghdr msg {};
-    std::size_t num_fds;
-    iovec data { &num_fds, sizeof(std::size_t) };
-    msg.msg_iov = &data;
-    msg.msg_iovlen = 1;
-    char cmsgbuf[CMSG_SPACE(sizeof(int))] {};
-    msg.msg_control = cmsgbuf;
-    msg.msg_controllen = sizeof(cmsgbuf);
+    std::array<std::size_t, 1> num_fds;
+    std::array<int, 1> fds;
+    auto sizes = std::make_pair(0ul, 0ul);
 
-    ReceiverPeer(acceptor, socket, msg).initiate();
+    ReceiverPeer(acceptor,
+                 socket,
+                 exios::buffer_view(num_fds),
+                 exios::buffer_view(fds),
+                 sizes)
+        .initiate();
 
     auto pid = ::fork();
     EXPECT(pid >= 0);
@@ -284,20 +296,19 @@ auto should_transfer_file_descriptors() -> void
     static_cast<void>(thread.run());
     ::waitpid(pid, nullptr, 0);
 
-    EXPECT(num_fds == 1);
-    EXPECT(msg.msg_controllen == CMSG_SPACE(sizeof(int)));
-    cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
-    EXPECT(cmsg);
-    EXPECT(cmsg->cmsg_len == CMSG_LEN(sizeof(int)));
-    int fd = *reinterpret_cast<int*>(CMSG_DATA(cmsg));
+    auto const& [data_bytes_received, control_bytes_received] = sizes;
 
-    EXIOS_SCOPE_GUARD([&] { ::close(fd); });
-    ::lseek(fd, 0, SEEK_SET);
+    EXPECT(data_bytes_received >= sizeof(num_fds[0]));
+    EXPECT(control_bytes_received >= sizeof(fds[0]));
+    EXPECT(num_fds[0] == 1);
+
+    EXIOS_SCOPE_GUARD([&] { ::close(fds[0]); });
+    ::lseek(fds[0], 0, SEEK_SET);
     std::string content;
 
     while (true) {
         char buffer[16] = {};
-        auto num_bytes = ::read(fd, &buffer, sizeof(buffer));
+        auto num_bytes = ::read(fds[0], &buffer, sizeof(buffer));
         EXPECT(num_bytes >= 0);
         std::copy_n(std::begin(buffer), num_bytes, std::back_inserter(content));
         if (!num_bytes)


### PR DESCRIPTION
Adds easier-to-use `send_message` and `receive_message` interfaces on `UnixSocket`. The new interfaces remove the need for callers pass in a `msghdr` structure and all its complicated buffer lifetime requirements. Instead, callers can now simply pass a buffer view for socket data and, optionally, a buffer view for control data. The implementation will take care of constructing the `msghdr` and its associated buffers.